### PR TITLE
Update max block weight for bit coin

### DIFF
--- a/src/consensus/consensus.h
+++ b/src/consensus/consensus.h
@@ -12,7 +12,7 @@
 /** The maximum allowed size for a serialized block, in bytes (only for buffer size limits) */
 static const unsigned int MAX_BLOCK_SERIALIZED_SIZE = 4000000;
 /** The maximum allowed weight for a block, see BIP 141 (network rule) */
-static const unsigned int MAX_BLOCK_WEIGHT = 4000000;
+static const unsigned int MAX_BLOCK_WEIGHT = 32000000;
 /** The maximum allowed number of signature check operations in a block (network rule) */
 static const int64_t MAX_BLOCK_SIGOPS_COST = 80000;
 /** Coinbase transaction outputs can only be spent after this number of new blocks (network rule) */


### PR DESCRIPTION
PR này em có đổi block weight lên cao hơn nhưng không rõ đổi chuẩn không em có kiểm tra đoạn validation này
[validation.cpp](https://github.com/huynguyen-quoc/bitcoin/blob/1811e488d53b82825e3523f6f0cdb97f635f03a7/src/validation.cpp#L3308)

Em có sửa và chạy lại test thì không thấy lỗi nên anh @phuongnd08 check dùm em với ạ